### PR TITLE
Add contract and testnet harness: advancedcounter

### DIFF
--- a/contracts/advancedcounter.scrypt
+++ b/contracts/advancedcounter.scrypt
@@ -1,0 +1,48 @@
+import "util.scrypt";
+
+/**
+ * Demonstrates TxAdvanced, with external funding (additional input),
+ * and a change output
+ */
+contract AdvancedCounter {
+	public function increment(bytes sighashPreimage, int amount, bytes changePKH, int changeSats) {
+
+		PrivKey privKey = PrivKey(b"ea401e7cedf9c428fbf9b92b75c90dfdd354394e58195d58e82bf79a8de31d62");
+		PubKey pubKey = PubKey(b"02773aca113a3217b67a95d5b78b69bb6386ed443ea5decf0ba92c00d179291921");
+		int invK = 0xa2103f96554aba49bbf581738d3b5a38c5a44b6238ffb54cfcca65b8c87ddc08;
+		int r = 0x00f0fc43da25095812fcddde7d7cd353990c62b078e1493dc603961af25dfc6b60;
+		bytes rBigEndian = b"00f0fc43da25095812fcddde7d7cd353990c62b078e1493dc603961af25dfc6b60";
+		bytes sigHashType = b"c1";
+
+		TxAdvanced tx = new TxAdvanced();
+		// this ensures the preimage is for the current tx
+		require(tx.validate(sighashPreimage, privKey, pubKey, invK, r, rBigEndian, sigHashType));
+
+		int len = length(sighashPreimage);
+		bytes hashOutputs = sighashPreimage[len - 40 : len - 8];
+		// scriptCode is just scriptPubKey if there is no CODESEPARATOR in the latter
+		bytes scriptCode = Util.readVarint(sighashPreimage[104:]);
+		int scriptLen = length(scriptCode);
+
+		// the last OP_RETURN byte contains the application state, i.e., counter
+		int counter = unpack(scriptCode[scriptLen - 1 :]);
+
+		// Expect the counter to be incremented in the new transaction state
+		bytes scriptCode_ = scriptCode[: scriptLen - 1] ++ num2bin(counter + 1, 1);
+
+		// Expect the additional CHANGE output
+		//    P2PKH:       DUP,HASH160  PKHLen      PKH      EQUALVERIFY,CHECKSIG
+		bytes changeScript = b"76a9" ++ b"14" ++  changePKH ++ b"88ac";
+		bytes extraOutputScript = num2bin(changeSats, 8) ++ Util.writeVarint(changeScript);
+
+		// output: amount + scriptlen + script
+		Sha256 hashOutputs_ = hash256(num2bin(amount, 8) ++ Util.writeVarint(scriptCode_)
+					++ extraOutputScript);
+
+		// ensure output matches what we expect:
+		//     - amount is same as specified
+		//     - output script is the same as scriptCode except the counter was incremented
+		//     - expected CHANGE output script is there
+		require(hashOutputs == hashOutputs_);
+    }
+}

--- a/tests/testnet/advancedcounter.js
+++ b/tests/testnet/advancedcounter.js
@@ -1,0 +1,84 @@
+const path = require('path');
+const { buildContractClass, lockScriptTx, unlockFundedScriptTx, getFundedSighashPreimage, showError } = require('scrypttest');
+
+const { num2SM } = require('../testHelper');
+
+// private key on testnet in WIF
+const key = ''
+if (!key) {
+    throw new Error('You must provide a private key');
+}
+// PKH for receiving change from each transaction (20 bytes - 40 hexadecimal characters)
+// Set this to your private key's PKH
+// bsv.crypto.Hash.sha256ripemd160(PubKey)
+const EXT_FUNDING_CHANGE_PKH = ''
+if (!EXT_FUNDING_CHANGE_PKH) {
+    throw new Error('You must provide a PKH for receiving change');
+}
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+(async() => {
+    try {
+        // get locking script
+        const AdvancedCounter = buildContractClass(path.join(__dirname, '../../contracts/advancedcounter.scrypt'))
+        const advCounter = new AdvancedCounter()
+
+        lockingScript = advCounter.getScriptPubKey()
+        // append state as passive data
+        let scriptPubKey = lockingScript + ' OP_RETURN 00'
+
+        // initial contract funding
+        let amount = 1000
+
+        // lock funds to the script
+        let txInfo = await lockScriptTx(scriptPubKey, key, amount)
+
+        let lockingTxid = txInfo.txid
+        console.log('funding txid:      ', lockingTxid)
+
+        // We'll pass-in the newChange, as part of the scriptSig
+
+        // Run five transactions /iterations
+        for (i = 0; i < 5; i++) {
+            // avoid mempool conflicts
+            // sleep to allow previous tx to "sink-into" the network
+            await sleep(9000);
+            console.log('==============================')
+            console.log('DONE SLEEPING before iteration ', i)
+            console.log('------------------------------')
+
+            // Set the state for the next transaction
+            const newScriptPubKey = lockingScript + ' OP_RETURN 0' + (i + 1)    // only works for i < 9
+            const newAmount = 1000  // keep the contract funding constant
+
+            // Get preimage, AND the change amount
+            console.log('====== Getting funded sighash preinage...')
+            const preData = await getFundedSighashPreimage(key, lockingTxid, scriptPubKey, amount, newScriptPubKey, newAmount)
+
+            console.log('Got preimage data: ', preData)
+            const preimage = preData.preimage
+            const changeASM = num2SM(preData.change)
+            const amountASM = num2SM(newAmount)
+
+            // Inform the contract how its state is being updated
+            // This format must match the contract's public function:
+            //             sighashPreimage     amount            changePKH                      changeSats
+            const scriptSig = preimage + ' ' + amountASM + ' ' + EXT_FUNDING_CHANGE_PKH + ' ' + changeASM
+
+            console.log(' ====== Unlocking...')
+            lockingTxid = await unlockFundedScriptTx(key, scriptSig, lockingTxid, scriptPubKey, amount, newScriptPubKey, newAmount)
+            console.log('iteration #' + i + ' txid: ', lockingTxid)
+
+            scriptPubKey = newScriptPubKey
+            amount = newAmount
+        }
+
+        console.log('Succeeded on testnet')
+    } catch (error) {
+        console.log('Failed on testnet')
+        showError(error)
+    }
+})()


### PR DESCRIPTION
Helps demonstrate use of TxAdvanced.

Demo requires specifying a PKH for receiving change (in addition to WIF private key).