### PR TITLE
add non-fungible token testnet

### DIFF
--- a/tests/testnet/nonFungibleToken.js
+++ b/tests/testnet/nonFungibleToken.js
@@ -1,0 +1,113 @@
+const path = require('path');
+const { bsv, buildContractClass, lockScriptTx, showError, literal2Asm } = require('scrypttest');
+const { getPreimage, signTx, sendTx, num2bin, genPrivKey, DataLen } = require('../testHelper');
+
+// private key on testnet in WIF
+const key = ''
+if (!key) {
+    genPrivKey()
+}
+
+(async() => {
+    const privateKeyIssuer = new bsv.PrivateKey.fromRandom('testnet')
+    const publicKeyIssuer = bsv.PublicKey.fromPrivateKey(privateKeyIssuer)
+    const privateKeyReceiver1 = new bsv.PrivateKey.fromRandom('testnet')
+    const publicKeyReceiver1 = bsv.PublicKey.fromPrivateKey(privateKeyReceiver1)
+    const privateKeyReceiver2 = new bsv.PrivateKey.fromRandom('testnet')
+    const publicKeyReceiver2 = bsv.PublicKey.fromPrivateKey(privateKeyReceiver2)
+    
+    try {
+        // get locking script
+        const NonFungibleToken = buildContractClass(path.join(__dirname, '../../contracts/nonFungibleToken.scrypt'))
+        const token = new NonFungibleToken()
+
+        // code part
+        const lockingScriptCodePart = token.getLockingScript()
+        
+        //read previous locking script: codePart + OP_RETURN + currTokenId + issuer
+
+
+        let currTokenId = 10;
+        // Issuer token 
+        let lockingScript = lockingScriptCodePart + ' OP_RETURN '  + num2bin(currTokenId, DataLen) + toHex(publicKeyIssuer)
+
+        token.setLockingScript(lockingScript)
+        
+        let inputSatoshis = 10000
+        const FEE = inputSatoshis / 4
+        let outputAmount = Math.floor((inputSatoshis - FEE) / 2)
+        // lock fund to the script
+        console.log('lock fund to the script start ...     ')
+        const lockingTxid = await lockScriptTx(lockingScript, key, inputSatoshis)
+        
+        console.log('funding txid:      ', lockingTxid)
+        
+        // increment token ID and issue two new token
+        let issuerTxid, lockingScript0, lockingScript1
+        {
+            const tx = new bsv.Transaction()
+            tx.addInput(new bsv.Transaction.Input({
+                prevTxId: lockingTxid,
+                outputIndex: 0,
+                script: ''
+            }), bsv.Script.fromASM(lockingScript), inputSatoshis)
+
+            lockingScript0 = lockingScriptCodePart + ' OP_RETURN ' + num2bin((currTokenId+1), DataLen) + toHex(publicKeyIssuer)
+            tx.addOutput(new bsv.Transaction.Output({
+                script: bsv.Script.fromASM(lockingScript0),
+                satoshis: outputAmount
+            }))
+
+            lockingScript1 = lockingScriptCodePart + ' OP_RETURN ' + num2bin(currTokenId, DataLen) + toHex(publicKeyReceiver1)
+            tx.addOutput(new bsv.Transaction.Output({
+                script: bsv.Script.fromASM(lockingScript1),
+                satoshis: outputAmount
+            }))
+
+            
+            const preimage = getPreimage(tx, lockingScript, 0, inputSatoshis)
+            const sig1 = signTx(tx, privateKeyIssuer, lockingScript, 0, inputSatoshis)
+            const unlockingScript = [toHex(sig1), toHex(publicKeyReceiver1),  literal2Asm(outputAmount), literal2Asm(outputAmount),
+                 toHex(preimage), literal2Asm(1)].join(' ')
+            tx.inputs[0].setScript(bsv.Script.fromASM(unlockingScript));
+            issuerTxid = await sendTx(tx);
+            console.log('issuer txid:       ', issuerTxid)
+        }
+
+
+        inputSatoshis = outputAmount
+        outputAmount -= FEE
+        // transfer token to publicKeyReceiver2
+        {
+
+            const tx = new bsv.Transaction()
+
+            tx.addInput(new bsv.Transaction.Input({
+                prevTxId: issuerTxid,
+                outputIndex: 1,
+                script: ''
+            }), bsv.Script.fromASM(lockingScript1), inputSatoshis)
+            console.log(tx);
+            let tokenId = 10;
+            const lockingScript2 = lockingScriptCodePart + ' OP_RETURN ' + num2bin(tokenId, DataLen) + toHex(publicKeyReceiver2)
+
+            tx.addOutput(new bsv.Transaction.Output({
+                script: bsv.Script.fromASM(lockingScript2),
+                satoshis: outputAmount
+            }))
+
+            const preimage = getPreimage(tx, lockingScript1, 0, inputSatoshis)
+            const sig2 = signTx(tx, privateKeyReceiver1, lockingScript1, 0, inputSatoshis)
+            const unlockingScript = [toHex(sig2), toHex(publicKeyReceiver2), literal2Asm(outputAmount), toHex(preimage), literal2Asm(2)].join(' ')
+            tx.inputs[0].setScript(bsv.Script.fromASM(unlockingScript));
+            console.log('sendTx transfer ...')
+            const transferTxid = await sendTx(tx);
+            console.log('transfer txid:       ', transferTxid)
+        }
+
+        console.log('Succeeded on testnet')
+    } catch (error) {
+        console.log('Failed on testnet')
+        showError(error)
+    }
+})()


### PR DESCRIPTION
add non-fungible token testnet



> node tests/testnet/tokennonFungible.js

lock fund to the script start ...
funding txid:       f0dfe68d8758cf6df7bcf71fb507ac9727a49c5b5dbdf1228794583eee88e1c4
issuer txid:           35e4540b17cd6a362aac0222524f79c1a72b58e053c2837900bdc1b601cdecdc
transfer txid:        c4056fa7b493bbb011dd7e19d57c8cd1ec3a4ac36771efe6a90448b7f15dced0
Succeeded on testnet

